### PR TITLE
Unwrap data on successful calls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -25,22 +25,27 @@ export default class Client {
   }
 
   get(...args) {
-    return this.instance.get(...args);
+    return this.instance.get(...args)
+    .then(r => r.data);
   }
 
   post(...args) {
-    return this.instance.post(...args);
+    return this.instance.post(...args)
+    .then(r => r.data);
   }
 
   patch(...args) {
-    return this.instance.patch(...args);
+    return this.instance.patch(...args)
+    .then(r => r.data);
   }
 
   put(...args) {
-    return this.instance.put(...args);
+    return this.instance.put(...args)
+    .then(r => r.data);
   }
 
   delete(...args) {
-    return this.instance.delete(...args);
+    return this.instance.delete(...args)
+    .then(r => r.data);
   }
 }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -15,4 +15,35 @@ describe('Client', () => {
   describe('post', async () => {
 
   });
+
+  it('unwraps data', async function() {
+    this.timeout(10000);
+    const apiBase = 'http://jsonip.com';
+    const logger = console;
+    const token = 'test';
+    const client = new Client({ apiBase, logger, token });
+    const data = await client.get('');
+    expect(data.ip).to.exist;
+    expect(data.status).to.not.exist;
+  });
+
+  it('throws on errors', async function() {
+    this.timeout(10000);
+    const apiBase = 'http://httpstat.us';
+    const logger = console;
+    const token = 'test';
+    const client = new Client({ apiBase, logger, token });
+
+    let thrown = false;
+
+    try {
+      await client.get('500');
+    } catch (e) {
+      thrown = true;
+      expect(e.response.status).to.equal(500);
+      expect(e.response.statusText).to.equal('Internal Server Error');
+    }
+
+    expect(thrown).to.equal(true);
+  });
 });


### PR DESCRIPTION
This makes the library a little more ergonomic to use. Since the Ordermentum API uses an envelope response, there's no need to have access to headers in a successful case.

The only time you may need access to the specific status code, etc, is on failure. In that case, it's all available from the thrown error.